### PR TITLE
🌿 Jitsi-Meet Custom SDK 기본 설정 🌿

### DIFF
--- a/ExampleApp/android/app/src/main/AndroidManifest.xml
+++ b/ExampleApp/android/app/src/main/AndroidManifest.xml
@@ -1,27 +1,28 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.exemple">
+    package="com.exemple">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-      android:name=".MainApplication"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme">
-      <activity
-        android:name=".MainActivity"
+        android:name=".MainApplication"
+        android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 
 </manifest>

--- a/ExampleApp/android/build.gradle
+++ b/ExampleApp/android/build.gradle
@@ -2,22 +2,28 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "30.0.3"
         minSdkVersion = 24
-        compileSdkVersion = 29
-        targetSdkVersion = 28
+        compileSdkVersion = 31
+        targetSdkVersion = 31
     }
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.2")
+        classpath("com.android.tools.build:gradle:4.2.2")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
+
+//def REACT_NATIVE_VERSION = new File(['node', '--print', "JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
 
 allprojects {
     repositories {
@@ -28,13 +34,20 @@ allprojects {
         }
 
         maven { // <---- Add this block
-            url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+            url "https://github.com/narvis2/Jitsi-Meet-Maven-Repository-5.1.0/raw/main/releases"
         }
         
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
+
+//        configurations.all {
+//            resolutionStrategy {
+//                // Remove this override in 0.66, as a proper fix is included in react-native itself.
+//                force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
+//            }
+//        }
 
         google()
         jcenter()

--- a/ExampleApp/android/gradle.properties
+++ b/ExampleApp/android/gradle.properties
@@ -25,4 +25,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.33.1
+FLIPPER_VERSION=0.99.0
+org.gradle.jvmargs=-Xmx4096m

--- a/ExampleApp/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ExampleApp/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ExampleApp/babel.config.js
+++ b/ExampleApp/babel.config.js
@@ -1,3 +1,10 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
+  presets: [
+    [
+      'module:metro-react-native-babel-preset',
+      {
+        unstable_disableES6Transforms: true,
+      },
+    ],
+  ],
 };

--- a/ExampleApp/package.json
+++ b/ExampleApp/package.json
@@ -11,17 +11,17 @@
   },
   "dependencies": {
     "react": "16.11.0",
-    "react-native": "0.62.2",
-    "react-native-jitsi-meet": "^2.1.1"
+    "react-native": "0.68.5",
+    "react-native-jitsi-meet": "git+https://github.com/narvis2/react-native-jitsi-meet-example.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.6.2",
+    "@babel/core": "7.12.9",
     "@babel/runtime": "^7.6.2",
     "@react-native-community/eslint-config": "^0.0.5",
     "babel-jest": "^24.9.0",
     "eslint": "^6.5.1",
     "jest": "^24.9.0",
-    "metro-react-native-babel-preset": "^0.58.0",
+    "metro-react-native-babel-preset": "0.59.0",
     "react-test-renderer": "16.11.0"
   },
   "jest": {


### PR DESCRIPTION
# 🌿 모든 작업은 ExampleApp 내부에서 이루어짐 🌿
## 🍀 react-native version update
- 0.62.2 👉 0.68.5

## 🍀 babel version update
### ☘️ babel/core
- @babel/core : ^7.6.2 👉 7.12.9

### ☘️ metro-react-native-babel-preset
- metro-react-native-babel-preset: ^0.58.0 👉 0.59.0

### ☘️ babel.config.js 수정
``` javascript
module.exports = {
  presets: [
    [
      'module:metro-react-native-babel-preset',
      {
        unstable_disableES6Transforms: true,
      },
    ],
  ],
};
```

## 🍀 build.gradle(project 수준)
- buildToolsVersion = "28.0.3" 👉 "30.0.3"
- compileSdkVersion = 29 👉 31
- targetSdkVersion = 28 👉 31
- maven url 설정 👇
``` gradle
repositories {
    google()
    jcenter()
    maven {
        url 'https://maven.google.com/'
        name 'Google'
    }
}
```
- tools.build:gradle 변경 👇
``` gradle
dependencies {
    classpath("com.android.tools.build:gradle:4.2.2")
}
```
- 하위 `Jitsi-Meet Custom SDK 적용` 👇
``` gradle
maven {
    url "https://github.com/narvis2/Jitsi-Meet-Maven-Repository-5.1.0/raw/main/releases"
}
```

## 🍀 gradle.properties
- FLIPPER_VERSION= 0.33.1 👉 0.99.0
- 메모리 부족 오류로 인해 추가 👉 `org.gradle.jvmargs=-Xmx4096m`

## 🍀 gradle-wrapper-properties
- `distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip` 로 변경

## 🍀 AndroidManifest.xml
-  targetSdkVersion 을 31 버전으로 타켓팅 했으므로 Android 12의 변경점에 따라 Activity 에 `export=true` 명시