### PR TITLE
🍎 Android SDK 0.0.3 Version 적용 🍎

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 repositories {
   maven {
-      url "https://github.com/narvis2/Jitsi-Meet-Custom-View-Example/raw/android-0.0.1-sdk/releases"
+      url "https://github.com/narvis2/Jitsi-Meet-Custom-View-Example/raw/main/releases"
   }
   google()
   mavenCentral()
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:0.0.1') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:0.0.3') {
       transitive = true
     }
 }


### PR DESCRIPTION
## 🍀 Android SDK 0.0.3 Version 적용
- `android/build.gradle` 하위 변경

  >  **_변경 사항_** 👇
  > 
  ``` gradle
  repositories {
      maven {
          url "https://github.com/narvis2/Jitsi-Meet-Custom-View-Example/raw/main/releases"
      }
      google()
      mavenCentral()
      jcenter()
    }

    dependencies {
        implementation ('org.jitsi.react:jitsi-meet-sdk:0.0.3') {
          transitive = true
        }
    }
  ```