### PR TITLE
🍎 Android > ForgroundService 사용 코드 추가 🍎

### DIFF
--- a/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetViewManager.java
+++ b/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetViewManager.java
@@ -2,7 +2,6 @@ package com.reactnativejitsimeet;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -10,11 +9,13 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.module.annotations.ReactModule;
 
+import org.jitsi.meet.sdk.JitsiMeetOngoingConferenceService;
 import org.jitsi.meet.sdk.JitsiMeetViewListener;
 
 import java.util.Map;
 
-import static java.security.AccessController.getContext;
+import android.content.Intent;
+import android.os.Build;
 
 @ReactModule(name = RNJitsiMeetViewManager.REACT_CLASS)
 public class RNJitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> implements JitsiMeetViewListener {
@@ -39,6 +40,18 @@ public class RNJitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> i
             view.setListener(this);
             mJitsiMeetViewReference.setJitsiMeetView(view);
         }
+
+        if (mReactContext != null) {
+            Intent intent = new Intent(mReactContext, JitsiMeetOngoingConferenceService.class);
+            intent.setAction(JitsiMeetOngoingConferenceService.Action.START.getName());
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                mReactContext.startForegroundService(intent);
+            } else {
+                mReactContext.startService(intent);
+            }
+        }
+
         return mJitsiMeetViewReference.getJitsiMeetView();
     }
 

--- a/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetViewManager.java
+++ b/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetViewManager.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import android.content.Intent;
 import android.os.Build;
+import android.util.Log;
 
 @ReactModule(name = RNJitsiMeetViewManager.REACT_CLASS)
 public class RNJitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> implements JitsiMeetViewListener {
@@ -46,6 +47,7 @@ public class RNJitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> i
             intent.setAction(JitsiMeetOngoingConferenceService.Action.START.getName());
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Log.e("Narvis2", "🦋🦋🦋 JitsiMeetOngoingConferenceService ForegroundService 시작 🦋🦋🦋");
                 mReactContext.startForegroundService(intent);
             } else {
                 mReactContext.startService(intent);


### PR DESCRIPTION
## 🍀 Android 에서 MediaProjection이 동작하지 않는 오류 수정
- 원인 👉 `MediaProjection` 은 `Service`가 실행되어 있어야 동작하는데 `ForegroundService`가 제대로 동작하지 않아 `MediaProjection`이 동작하지 않음
- 해결 👉 `RNJitsiMeetView`가 생성되면 `JitsiMeetOngoingConferenceService` 를 `Version`에 따라 실행시켜주는 로직 추가

  >  **_참고_** 👇
  > - `ForegroundService`가 제대로 동작하였으면 `Notification` 알림이 노출되어야 하는데, `Notification` 알림이 노출되지 않음
  > - 위와 같은 이유로 `ForegroundService`가 제대로 동작하지 않았다고 생각함