### PR TITLE
🍎Android > ForegroundService 실행 코드 변경 🍎

### DIFF
--- a/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetViewManager.java
+++ b/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetViewManager.java
@@ -42,18 +42,6 @@ public class RNJitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> i
             mJitsiMeetViewReference.setJitsiMeetView(view);
         }
 
-        if (mReactContext != null) {
-            Intent intent = new Intent(mReactContext, JitsiMeetOngoingConferenceService.class);
-            intent.setAction(JitsiMeetOngoingConferenceService.Action.START.getName());
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Log.e("Narvis2", "🦋🦋🦋 JitsiMeetOngoingConferenceService ForegroundService 시작 🦋🦋🦋");
-                mReactContext.startForegroundService(intent);
-            } else {
-                mReactContext.startService(intent);
-            }
-        }
-
         return mJitsiMeetViewReference.getJitsiMeetView();
     }
 
@@ -64,6 +52,19 @@ public class RNJitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> i
                 mJitsiMeetViewReference.getJitsiMeetView().getId(),
                 "conferenceJoined",
                 event);
+
+        if (mReactContext != null) {
+            Intent intent = new Intent(mReactContext, JitsiMeetOngoingConferenceService.class);
+            intent.setAction(JitsiMeetOngoingConferenceService.Action.START.getName());
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Log.e("Narvis2", "🦋🦋🦋 JitsiMeetOngoingConferenceService ForegroundService 시작 🦋🦋🦋");
+                mReactContext.startForegroundService(intent);
+
+            } else {
+                mReactContext.startService(intent);
+            }
+        }
     }
 
     public void onConferenceTerminated(Map<String, Object> data) {


### PR DESCRIPTION
## 🍀 Android ForegroundService 실행 코드 변경
- 오류 👉 `createViewInstance()` 함수 내부에서  `mReactContext.startForegroundService()` 했더니 `Cannot create notification: no current context` 오류 발생하여 `RuntimeException` 발생
- 해결 방안 👉 `Jitsi-Meet-Custom` 에서 `Notification Channel`을 `onConferenceJoined()`에서 하고 있으므로 `react-native-jitsi-meet-example`에서도 `onConferenceJoined` 할때 `mReactContext.startForegroundService()` 실행하도록 변경