### PR TITLE
ios-sdk-v0.0.6 update

### DIFF
--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency 'React'
-  s.dependency 'JitsiMeetSDK', '0.0.4'
+  s.dependency 'JitsiMeetSDK', '0.0.6'
 end


### PR DESCRIPTION
0.0.4 pods 설치시 2.3.1 버전을 바라보고 있어 다시 sdk를 0.0.6 말아서 업데이트 진행