### PR TITLE
업데이트 된 CustomJitsiMeetSDK 버전을 가져오기위해서 0.0.6 => 0.0.7 업데이트

### DIFF
--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency 'React'
-  s.dependency 'CustomJitsiMeetSDK', '0.0.6'
+  s.dependency 'CustomJitsiMeetSDK', '0.0.7'
 end


### PR DESCRIPTION
customJitsiMeet 업데이트를 위해서 podsepc 수정(0.0.6 => `0.0.7`)